### PR TITLE
Shio/refactoring code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RM = rm
 FSANITIZE = -fsanitize=address
 CFLAGS = -Wall -Wextra -Werror 
 INCLUDES = -I./includes -I/usr/local/opt/readline/include
-READLINE = -lreadline -L/usr/local/opt/readline/lib
+READLINE = -lreadline -L/usr/local/opt/readline/lib 
 
 LIBFT_DIR = libft
 LIBFT = $(LIBFT_DIR)/libft.a
@@ -17,11 +17,16 @@ SRCS =\
 error.c\
 execve.c\
 heredocument.c\
-pipe.c\
 redirect.c\
 signal.c\
 free.c \
 stdio_fd_utils.c \
+
+# pipe
+PIPE_SRCS =\
+pipe.c \
+pipe_command.c \
+pipe_utils.c \
 
 # builtin
 BUILTIN_SRCS =\
@@ -51,7 +56,7 @@ parser_quote_env.c\
 parser_redirect.c\
 parser.c
 
-SRCS += $(BUILTIN_SRCS)	$(ENV_SRCS) $(PARSER_SRCS)
+SRCS += $(PIPE_SRCS) $(BUILTIN_SRCS)	$(ENV_SRCS) $(PARSER_SRCS)
 
 OBJ_DIR = objs
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRCS:.c=.o))

--- a/builtin_exit.c
+++ b/builtin_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 00:54:17 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/16 01:52:28 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/19 04:37:17 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,6 @@ int is_numeric(const char *str) {
 }
 
 int builtin_exit(char **cmd, t_list *env) {
-    int exit_status = g_last_exit_status;
 
 	(void)env;
     write(STDOUT_FILENO, "exit\n", 5);
@@ -40,16 +39,14 @@ int builtin_exit(char **cmd, t_list *env) {
             write(STDERR_FILENO, "exit: ", 6);
             write(STDERR_FILENO, cmd[1], ft_strlen(cmd[1]));
             write(STDERR_FILENO, ": numeric argument required\n", 28);
-            exit_status = 255;
-            return(-1);
+            g_last_exit_status = 255;
         }
         if (cmd[2] != NULL) {
             write(STDERR_FILENO, "exit: too many arguments\n", 26);
             g_last_exit_status = 1;
-            return (1);
+            return (-1);
         }
-        exit_status = ft_atoi(cmd[1]) % 256;
+        g_last_exit_status = ft_atoi(cmd[1]) & 0xFF;  // ビットマスクで確実に0-255に制限;
     }
-    g_last_exit_status = exit_status;
     return (0);
 }

--- a/execve.c
+++ b/execve.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execve.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 03:20:59 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/17 22:32:03 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:15:08 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,10 +82,8 @@ void execute_cmd(char **cmd, t_list *env)
     {
         (void)error_msg(cmd_path, strerror(errno));
         if (cmd_path != cmd[0])
-            free(cmd_path);	// cmd_pathをfreeするならenv_arrayもfreeして良いのでは
+            free(cmd_path);
 		free_double_pointor(env_array);
-        // env_arrayのクリーンアップは不要（execve成功時はプロセスが置き換わり、
-        // 失敗時はexit()で終了するため）<- ?
         exit(EXIT_FAILURE);
     }
 }

--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 21:59:46 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/18 15:55:32 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/19 04:49:30 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,8 +65,9 @@ int	main(int argc, char **argv, char **envp)
 		line = readline(PROMPT);
 		if (!line)
 		{
-			write(1, "exit\n", 5);
-			break ;
+			// EOF(Ctrl+D)の場合、余分な行を入れずに"exit"だけ表示
+			ft_putstr_fd("exit", STDOUT_FILENO);
+			break;
 		}
 		if (ft_strlen(line) > 0)
 		{

--- a/pipe.c
+++ b/pipe.c
@@ -6,159 +6,42 @@
 /*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/16 01:16:07 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/16 23:34:24 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/19 03:40:19 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-# include <minishell.h>
+#include <minishell.h>
 
-int execute_pipeline(t_cmd **cmds, t_builtin *builtins, t_list *env)
+static bool check_pipeline(t_cmd **cmds, int *cmd_count)
 {
-    // パイプラインが存在するかチェック
-    bool is_pipeline = false;
-    int cmd_count = 0;
-    while (cmds[cmd_count])
-        cmd_count++;
-    if (cmd_count > 1)
-        is_pipeline = true;
-
-    // 単一コマンドかつビルトインの場合、親プロセスで直接実行
-    if (!is_pipeline)
-    {
-        int is_builtin_index = get_builtin_index(builtins, cmds[0]->cmd[0]);
-        if (is_builtin_index >= 0)
-        {
-            setup_builtin_signals();
-            
-            // ヒアドキュメントとリダイレクト処理
-            for (int j = 0; cmds[0]->input_rdrct[j]; j++)
-            {
-                if (cmds[0]->input_rdrct[j]->type == HEREDOCUMENT)
-                {
-                    if (handle_heredocument(cmds[0]->input_rdrct[j]->file[0], cmds[0]) == -1)
-                        return EXIT_FAILURE;
-                }
-            }
-            
-            // リダイレクト処理
-            if (handle_redirection(cmds[0]) == -1)
-                return EXIT_FAILURE;
-                
-            // ビルトイン実行
-            int result = builtins[is_builtin_index].func(cmds[0]->cmd, env);
-            
-            // リダイレクトを元に戻す
-            restore_redirection(cmds[0]);
-            
-            // exit コマンドの特別処理
-            if (ft_strcmp(cmds[0]->cmd[0], "exit") == 0)
-            {
-                g_last_exit_status = result;
-                return -42;  // シェル終了を示す特別な値
-            }
-            
-            g_last_exit_status = result;
-            setup_interactive_signals();
-            return result;
-        }
-    }
-
-    // ここから複数コマンドのパイプライン処理、または単一の外部コマンド処理
-    int pipe_fds[2];
-    int prev_fd = -1;
-    int status;
-    int i = 0;
-    pid_t *pids = (pid_t *)malloc(sizeof(pid_t) * cmd_count);
-    if (!pids)
-        return EXIT_FAILURE;
-
-    // 以降は前回提案した内容と同じ（すべてのコマンドを子プロセスで実行）
-    while (cmds[i])
-    {
-        if (cmds[i + 1])
-        {
-            if (pipe(pipe_fds) == -1)
-            {
-                perror("pipe");
-                free(pids);
-                return (EXIT_FAILURE);
-            }
-        }
-
-        int is_builtin_index = get_builtin_index(builtins, cmds[i]->cmd[0]);
+    bool is_pipeline;
+    
+    *cmd_count = 0;
+    while (cmds[*cmd_count])
+        (*cmd_count)++;
         
-        setup_exec_signals();
-        pid_t pid = fork();
-        if (pid == -1)
-        {
-            perror("fork");
-            free(pids);
-            return EXIT_FAILURE;
-        }
+    is_pipeline = (*cmd_count > 1);
+    return is_pipeline;
+}
 
-        if (pid == 0)
-        {
-            // 子プロセスの処理（前回と同様）
-            setup_child_signals();
-            
-            // ヒアドキュメント処理
-            for (int j = 0; cmds[i]->input_rdrct[j]; j++)
-            {
-                if (cmds[i]->input_rdrct[j]->type == HEREDOCUMENT)
-                {
-                    if (handle_heredocument(cmds[i]->input_rdrct[j]->file[0], cmds[i]) == -1)
-                        exit(EXIT_FAILURE);
-                }
-            }
+static int handle_single_builtin(t_cmd *cmd, t_builtin *builtins, t_list *env)
+{
+    int is_builtin_index;
+    
+    is_builtin_index = get_builtin_index(builtins, cmd->cmd[0]);
+    if (is_builtin_index >= 0)
+        return execute_single_builtin(cmd, builtins, is_builtin_index, env);
+    
+    return -1;
+}
 
-            // リダイレクト処理
-            if (handle_redirection(cmds[i]) == -1)
-                exit(EXIT_FAILURE);
-
-            // パイプの設定
-            if (prev_fd != -1)
-            {
-                dup2(prev_fd, STDIN_FILENO);
-                close(prev_fd);
-            }
-            if (cmds[i + 1])
-            {
-                dup2(pipe_fds[1], STDOUT_FILENO);
-                close(pipe_fds[1]);
-                close(pipe_fds[0]);
-            }
-
-            // ビルトインまたは外部コマンド実行
-            if (is_builtin_index >= 0)
-            {
-                int result = builtins[is_builtin_index].func(cmds[i]->cmd, env);
-                exit(result);
-            }
-            else
-            {
-                execute_cmd(cmds[i]->cmd, env);
-            }
-        }
-        else
-        {
-            // 親プロセスの処理（前回と同様）
-            pids[i] = pid;
-
-            if (prev_fd != -1)
-            {
-                close(prev_fd);
-            }
-            if (cmds[i + 1])
-            {
-                close(pipe_fds[1]);
-                prev_fd = pipe_fds[0];
-            }
-        }
-        i++;
-    }
-
-    // 子プロセスの待機処理
-    for (i = 0; i < cmd_count; i++)
+int wait_for_children(pid_t *pids, int cmd_count)
+{
+    int status;
+    int i;
+    
+    i = 0;
+    while (i < cmd_count)
     {
         waitpid(pids[i], &status, 0);
         if (i == cmd_count - 1)
@@ -168,8 +51,34 @@ int execute_pipeline(t_cmd **cmds, t_builtin *builtins, t_list *env)
             else if (WIFSIGNALED(status))
                 g_last_exit_status = WTERMSIG(status) + 128;
         }
+        i++;
     }
+    
+    return g_last_exit_status;
+}
 
+int execute_pipeline(t_cmd **cmds, t_builtin *builtins, t_list *env)
+{
+    int cmd_count;
+    pid_t *pids;
+    t_pipe_info pipe_info;
+    
+    if (!check_pipeline(cmds, &cmd_count))
+    {
+        int result = handle_single_builtin(cmds[0], builtins, env);
+        if (result != -1)
+            return result;
+    }
+    
+    pids = (pid_t *)malloc(sizeof(pid_t) * cmd_count);
+    if (!pids)
+        return EXIT_FAILURE;
+        
+    pipe_info.prev_fd = -1;
+    execute_commands(cmds, builtins, env, pids, &pipe_info);
+    
+    wait_for_children(pids, cmd_count);
+    
     free(pids);
     setup_interactive_signals();
     return g_last_exit_status;

--- a/pipe_command.c
+++ b/pipe_command.c
@@ -1,0 +1,127 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pipe_command.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 12:30:41 by shiori            #+#    #+#             */
+/*   Updated: 2025/03/19 04:37:51 by shiori           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+int execute_single_builtin(t_cmd *cmd, t_builtin *builtins, 
+                           int builtin_index, t_list *env)
+{
+    int result;
+    
+    setup_builtin_signals();
+    
+    if (process_heredocs(cmd) == -1)
+        return EXIT_FAILURE;
+    
+    if (handle_redirection(cmd) == -1)
+        return EXIT_FAILURE;
+    
+    result = builtins[builtin_index].func(cmd->cmd, env);
+    if (ft_strcmp(cmd->cmd[0], "exit") != 0)
+        g_last_exit_status = result;
+    
+    restore_redirection(cmd);
+    
+    if (ft_strcmp(cmd->cmd[0], "exit") == 0)
+    {
+        if (result == -1)
+        {
+            setup_interactive_signals();
+            return (1);
+        }
+        return (-42);
+    }
+    setup_interactive_signals();
+    return result;
+}
+
+void execute_command_in_child(t_cmd *cmd, int (*builtin_func)(char **, t_list *), 
+                             t_list *env, t_pipe_info *pipe_info)
+{
+    setup_child_signals();
+    
+    if (process_heredocs(cmd) == -1)
+        exit(EXIT_FAILURE);
+
+    if (handle_redirection(cmd) == -1)
+        exit(EXIT_FAILURE);
+
+    if (pipe_info->prev_fd != -1)
+    {
+        dup2(pipe_info->prev_fd, STDIN_FILENO);
+        close(pipe_info->prev_fd);
+    }
+    if (pipe_info->has_next)
+    {
+        dup2(pipe_info->pipe_fds[1], STDOUT_FILENO);
+        close(pipe_info->pipe_fds[1]);
+        close(pipe_info->pipe_fds[0]);
+    }
+
+    if (builtin_func)
+    {
+        int result = builtin_func(cmd->cmd, env);
+        exit(result);  
+    }
+    else
+    {
+        execute_cmd(cmd->cmd, env);
+    }
+}
+
+static pid_t prepare_command(t_cmd *cmd, t_builtin *builtins, 
+                            t_list *env, t_pipe_info *pipe_info)
+{
+    int (*builtin_func)(char **, t_list *);
+    pid_t pid;
+    
+    builtin_func = NULL;
+    if (get_builtin_index(builtins, cmd->cmd[0]) >= 0)
+        builtin_func = builtins[get_builtin_index(builtins, cmd->cmd[0])].func;
+    
+    setup_exec_signals();
+    pid = fork();
+    if (pid == -1)
+    {
+        perror("fork");
+        return -1;
+    }
+    
+    if (pid == 0)
+        execute_command_in_child(cmd, builtin_func, env, pipe_info);
+    
+    return pid;
+}
+
+int execute_commands(t_cmd **cmds, t_builtin *builtins, t_list *env, 
+                    pid_t *pids, t_pipe_info *pipe_info)
+{
+    int i;
+    pid_t pid;
+    
+    i = 0;
+    while (cmds[i])
+    {
+        if (setup_pipe(pipe_info, cmds[i + 1] != NULL) == -1)
+            return -1;
+            
+        pid = prepare_command(cmds[i], builtins, env, pipe_info);
+        if (pid == -1)
+            return -1;
+            
+        pids[i] = pid;
+        manage_parent_pipes(pipe_info);
+        i++;
+    }
+    
+    return i;
+}

--- a/pipe_utils.c
+++ b/pipe_utils.c
@@ -1,0 +1,58 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pipe_utils.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 12:30:41 by shiori            #+#    #+#             */
+/*   Updated: 2025/03/19 02:59:56 by shiori           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+int process_heredocs(t_cmd *cmd)
+{
+    int j;
+    
+    j = 0;
+    while (cmd->input_rdrct[j])
+    {
+        if (cmd->input_rdrct[j]->type == HEREDOCUMENT)
+        {
+            if (handle_heredocument(cmd->input_rdrct[j]->file[0], cmd) == -1)
+                return -1;
+        }
+        j++;
+    }
+    return 0;
+}
+
+int setup_pipe(t_pipe_info *pipe_info, bool has_next)
+{
+    pipe_info->has_next = has_next;
+    
+    if (has_next)
+    {
+        if (pipe(pipe_info->pipe_fds) == -1)
+        {
+            perror("pipe");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void manage_parent_pipes(t_pipe_info *pipe_info)
+{
+    if (pipe_info->prev_fd != -1)
+        close(pipe_info->prev_fd);
+        
+    if (pipe_info->has_next)
+    {
+        close(pipe_info->pipe_fds[1]);
+        pipe_info->prev_fd = pipe_info->pipe_fds[0];
+    }
+}
+

--- a/redirect.c
+++ b/redirect.c
@@ -6,7 +6,7 @@
 /*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/16 20:05:03 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/16 20:39:15 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/19 17:03:34 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ int handle_redirection(t_cmd *cmd)
     {
         if (cmd->input_rdrct[j]->type == INPUT_RDRCT)
         {
-            cmd->backup_stdin = dup(STDIN_FILENO);  // 毎回バックアップを取る
+            cmd->backup_stdin = dup(STDIN_FILENO);
             if (cmd->backup_stdin == -1)
             {
                 perror("dup");
@@ -29,7 +29,10 @@ int handle_redirection(t_cmd *cmd)
             cmd->infile_fd = open(cmd->input_rdrct[j]->file[0], O_RDONLY);
             if (cmd->infile_fd == -1)
             {
-                perror("open");
+                ft_putstr_fd(cmd->input_rdrct[j]->token, STDERR_FILENO);
+                ft_putstr_fd(": ", STDERR_FILENO);
+                perror("");
+                restore_redirection(cmd);  // エラー時に元の状態に戻す
                 return -1;
             }
             dup2(cmd->infile_fd, STDIN_FILENO);
@@ -40,7 +43,7 @@ int handle_redirection(t_cmd *cmd)
     // 出力リダイレクト処理
     for (int j = 0; cmd->output_rdrct[j]; j++)
     {
-        cmd->backup_stdout = dup(STDOUT_FILENO);  // 毎回バックアップを取る
+        cmd->backup_stdout = dup(STDOUT_FILENO);
         if (cmd->backup_stdout == -1)
         {
             perror("dup");
@@ -56,7 +59,10 @@ int handle_redirection(t_cmd *cmd)
         cmd->outfile_fd = open(cmd->output_rdrct[j]->file[0], flags, 0644);
         if (cmd->outfile_fd == -1)
         {
-            perror("open");
+            ft_putstr_fd(cmd->output_rdrct[j]->token, STDERR_FILENO);
+            ft_putstr_fd(": ", STDERR_FILENO);
+            perror("");
+            restore_redirection(cmd);  // エラー時に元の状態に戻す
             return -1;
         }
         dup2(cmd->outfile_fd, STDOUT_FILENO);


### PR DESCRIPTION
・パイプの処理を部品化しました。
・終了コードについてexitに複数の引数が渡された時にシェルを終了させないようにする処理を消してしまったので復活させました。

・複数のリダイレクト実行時に各ファイルのオープンは実装できていたため、エラー処理にtokenを使用してエラー出力を行うようにしました。マージして問題なければ次のコミットでnorm対応します。
