### PR TITLE
複数のヒアドキュメントを考慮した実装に修正

### DIFF
--- a/heredocument.c
+++ b/heredocument.c
@@ -6,28 +6,35 @@
 /*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 17:33:18 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/19 20:14:07 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 02:39:44 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-static int	setup_heredoc_pipe(int pipe_fds[2], t_cmd *cmd)
+static int setup_heredoc_pipe(int pipe_fds[2], t_cmd *cmd)
 {
-	if (pipe(pipe_fds) == -1)
-	{
-		perror("pipe");
-		return (-1);
-	}
-	cmd->backup_stdin = dup(STDIN_FILENO);
-	if (cmd->backup_stdin == -1)
-	{
-		perror("dup");
-		close(pipe_fds[0]);
-		close(pipe_fds[1]);
-		return (-1);
-	}
-	return (0);
+    if (pipe(pipe_fds) == -1)
+    {
+        perror("pipe");
+        return (-1);
+    }
+    if (cmd->backup_stdin == -1)
+    {
+        cmd->backup_stdin = dup(STDIN_FILENO);
+        if (cmd->backup_stdin == -1)
+        {
+            perror("dup");
+            close(pipe_fds[0]);
+            close(pipe_fds[1]);
+            return (-1);
+        }
+    }
+    else
+    {
+        dup2(cmd->backup_stdin, STDIN_FILENO);
+    }
+    return (0);
 }
 
 static void	process_heredoc_child(int pipe_fds[2], char *delimiter)
@@ -51,6 +58,7 @@ static void	process_heredoc_child(int pipe_fds[2], char *delimiter)
 		free(line);
 	}
 	close(pipe_fds[1]);
+	exit(0);
 }
 
 static int	setup_parent_process(int pipe_fds[2], t_cmd *cmd, pid_t pid)


### PR DESCRIPTION
ご確認お願いします。
複数ヒアドキュメントの対応:
最初のヒアドキュメント処理時のみバックアップを保存
2回目以降は前のヒアドキュメント内容を破棄するために元の標準入力に一度戻す
子プロセスの確実な終了:
process_heredoc_child関数の最後にexit(0)を追加して子プロセスが確実に終了するようにする