### PR TITLE
Hhkoizumi/fix-with-tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pyminish
 .devcontainer/
 .vscode/
 test.sh
+minishell_tester/

--- a/builtin_env.c
+++ b/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 00:48:52 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/18 12:19:49 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 03:17:08 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ static int	print_env(t_list *env_list)
 	{
 		env_content = (t_env *)env_list_tmp->content;
 		env_list_tmp = env_list_tmp->next;
-		if (env_content->is_shell_var)
+		if (env_content->is_shell_var || !env_content->value)
 			continue ;
 		if (printf("%s=%s\n", env_content->key, env_content->value) < 0)
 			return (1);

--- a/builtin_exit.c
+++ b/builtin_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 00:54:17 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/19 04:37:17 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 03:33:11 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,8 +40,9 @@ int builtin_exit(char **cmd, t_list *env) {
             write(STDERR_FILENO, cmd[1], ft_strlen(cmd[1]));
             write(STDERR_FILENO, ": numeric argument required\n", 28);
             g_last_exit_status = 255;
+			return (0);
         }
-        if (cmd[2] != NULL) {
+        else if (cmd[2] != NULL) {
             write(STDERR_FILENO, "exit: too many arguments\n", 26);
             g_last_exit_status = 1;
             return (-1);

--- a/execve.c
+++ b/execve.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execve.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 03:20:59 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/19 16:15:08 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 04:09:48 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ void execute_cmd(char **cmd, t_list *env)
 {
     char *cmd_path;
     char **env_array;
+	struct stat path_stat;
 
     cmd_path = (ft_strchr(cmd[0], '/') != NULL) ? cmd[0] : find_cmd_path(cmd[0], env);
     if (!cmd_path)
@@ -77,7 +78,22 @@ void execute_cmd(char **cmd, t_list *env)
             free(cmd_path);
         exit(EXIT_FAILURE);
     }
-
+	if (stat(cmd_path, &path_stat) == -1)
+	{
+		(void)error_msg(cmd_path, strerror(errno));
+		if (cmd_path != cmd[0])
+			free(cmd_path);
+		free_double_pointor(env_array);
+		exit(EXIT_FAILURE);
+	}
+	if (S_ISDIR(path_stat.st_mode))
+	{
+		(void)error_msg(cmd_path, "is a directory");
+		if (cmd_path != cmd[0])
+			free(cmd_path);
+		free_double_pointor(env_array);
+		exit(EXIT_FAILURE);
+	}
     if (execve(cmd_path, cmd, env_array) == -1)
     {
         (void)error_msg(cmd_path, strerror(errno));

--- a/execve.c
+++ b/execve.c
@@ -6,15 +6,17 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 03:20:59 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 04:09:48 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:43:20 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-int is_executable(char *path) {
-    struct stat sb;
-    return (stat(path, &sb) == 0 && S_ISREG(sb.st_mode) && (sb.st_mode & S_IXUSR));
+bool	is_exist(char *path)
+{
+	struct stat	sb;
+
+	return (stat(path, &sb) == 0);
 }
 
 char *concat_path_cmd(char *dir, char *cmd) {
@@ -31,76 +33,80 @@ char *concat_path_cmd(char *dir, char *cmd) {
     return cmd_path;
 }
 
-char *find_cmd_path(char *cmd, t_list *env) {
-	t_env	*path_env;
+bool	find_cmd_path(char **cmd_path, char *cmd, t_env *path_env) {
     char **path_dirs;
-    char *cmd_path;
     int i;
     
-	path_env = env_get(env, "PATH", false);
-	if (!path_env || !path_env->value)
-		return (cmd);
     path_dirs = ft_split(path_env->value, ':');
     if (!path_dirs) 
-        return NULL;
+        return false;
     i=0;
     while (path_dirs[i]) {
-        cmd_path = concat_path_cmd(path_dirs[i], cmd);
-        if (is_executable(cmd_path)) {
+        *cmd_path = concat_path_cmd(path_dirs[i], cmd);
+        if (is_exist(*cmd_path)) {
             free_double_pointor(path_dirs);
-            return cmd_path;
+            return true;
         }
-        free(cmd_path);
+        free(*cmd_path);
         i++;
     }
     free_double_pointor(path_dirs);
-    return NULL;
+	*cmd_path = NULL;
+    return true;
 }
 
 void execute_cmd(char **cmd, t_list *env)
 {
+	t_env	*path_env;
     char *cmd_path;
     char **env_array;
 	struct stat path_stat;
 
-    cmd_path = (ft_strchr(cmd[0], '/') != NULL) ? cmd[0] : find_cmd_path(cmd[0], env);
+	path_env = env_get(env, "PATH", false);
+	if (ft_strchr(cmd[0], '/') || !path_env || !path_env->value)
+		cmd_path = ft_strdup(cmd[0]);
+	else if (!find_cmd_path(&cmd_path, cmd[0], path_env))
+		exit(perror_int("malloc", errno));
     if (!cmd_path)
     {
-        write(STDERR_FILENO, cmd[0], ft_strlen(cmd[0]));
-        write(STDERR_FILENO, ": command not found\n", 20);  
-        exit(EXIT_FAILURE);
+		ft_putstr_fd("minishell: ", STDERR_FILENO);
+		ft_putstr_fd(cmd[0], STDERR_FILENO);
+		ft_putstr_fd(": command not found\n", STDERR_FILENO);
+        exit(127);
     }
 
-    env_array = convert_env_list_to_array(env);
-    if (!env_array)
-    {
-        if (cmd_path != cmd[0])
-            free(cmd_path);
-        exit(EXIT_FAILURE);
-    }
 	if (stat(cmd_path, &path_stat) == -1)
 	{
 		(void)error_msg(cmd_path, strerror(errno));
 		if (cmd_path != cmd[0])
 			free(cmd_path);
-		free_double_pointor(env_array);
-		exit(EXIT_FAILURE);
+		if (errno == ENOENT)
+			exit(127);
+		exit(126);
 	}
 	if (S_ISDIR(path_stat.st_mode))
 	{
 		(void)error_msg(cmd_path, "is a directory");
 		if (cmd_path != cmd[0])
 			free(cmd_path);
-		free_double_pointor(env_array);
-		exit(EXIT_FAILURE);
+		exit(126);
 	}
+    env_array = convert_env_list_to_array(env);
+    if (!env_array)
+    {
+        if (cmd_path != cmd[0])
+            free(cmd_path);
+        exit(perror_int("malloc", errno));
+    }
     if (execve(cmd_path, cmd, env_array) == -1)
     {
         (void)error_msg(cmd_path, strerror(errno));
         if (cmd_path != cmd[0])
             free(cmd_path);
 		free_double_pointor(env_array);
-        exit(EXIT_FAILURE);
+		if (errno == ENOENT)
+			exit(127);
+		exit(126);
     }
 }
 

--- a/execve.c
+++ b/execve.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 03:20:59 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 11:43:20 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:49:07 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,9 +69,7 @@ void execute_cmd(char **cmd, t_list *env)
 		exit(perror_int("malloc", errno));
     if (!cmd_path)
     {
-		ft_putstr_fd("minishell: ", STDERR_FILENO);
-		ft_putstr_fd(cmd[0], STDERR_FILENO);
-		ft_putstr_fd(": command not found\n", STDERR_FILENO);
+		(void)error_msg(cmd[0], "command not found");
         exit(127);
     }
 

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 21:59:46 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/19 23:44:08 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 04:11:16 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,10 @@ int	main(int argc, char **argv, char **envp)
 			add_history(line);
 			cmds = parser(line, g_last_exit_status, env);
 			if (!cmds)
+			{
+				free(line);
 				continue ;
+			}
 			status = execute_pipeline(cmds, builtins, env);
 			if (status == -42)
 			{

--- a/parser_expand_env_quote_utils.c
+++ b/parser_expand_env_quote_utils.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 21:43:48 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/19 23:06:56 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 03:22:04 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,8 +68,9 @@ static char	*noenv_remain(char **token, t_parser *data, t_quote quote, int len)
 	expanded = NULL;
 	tmp = *token;
 	i = 0;
-	while (tmp[i] && !is_effective_quote(tmp[i], &quote) && !(quote != SINGLE_Q
-			&& tmp[i] == '$' && (ft_isalnum(tmp[i + 1]) || tmp[i + 1] == '_')))
+	while (tmp[i] && !is_effective_quote(tmp[i], &quote)
+		&& !(quote != SINGLE_Q && tmp[i] == '$' && (tmp[i + 1]
+				&& (ft_isalnum(tmp[i + 1]) || ft_strchr("_?", tmp[i + 1])))))
 		i++;
 	move_arg_pointer(token, data, tmp, i);
 	if (!tmp[i])

--- a/parser_syntax.c
+++ b/parser_syntax.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/18 23:24:37 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/19 21:50:11 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 04:15:56 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,6 +74,7 @@ static bool	print_syntax_error(char *token)
 {
 	ft_putstr_fd("minishell: syntax error near unexpected token `", 2);
 	ft_putstr_fd(token, 2);
-	ft_putstr_fd("`\n", 2);
+	ft_putstr_fd("'\n", 2);
+	g_last_exit_status = 258;
 	return (false);
 }

--- a/parser_syntax.c
+++ b/parser_syntax.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/18 23:24:37 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/20 04:15:56 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:23:52 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,10 +31,10 @@ bool	check_syntax(t_list *tokens)
 		token = (char *)cur->content;
 		if (!is_quote_closed(token))
 			return (print_syntax_error(token));
-		if ((prev && ft_strncmp(prev, "|", 2) == 0
-				&& ft_strncmp(token, "|", 2) == 0)
+		if ((!prev && !ft_strncmp(token, "|", 2))
+			|| (prev && !ft_strncmp(prev, "|", 2) && !ft_strncmp(token, "|", 2))
 			|| (prev && is_rdrct(prev)
-				&& (ft_strncmp(token, "|", 2) == 0 || is_rdrct(token))))
+				&& (!ft_strncmp(token, "|", 2) || is_rdrct(token))))
 			return (print_syntax_error(token));
 		prev = token;
 		cur = cur->next;


### PR DESCRIPTION
- envの出力修正
valueが設定されていない環境変数をスキップ
- exitの修正
正常なタイミングでのreturn処理の追加
- execveのパス検索とバリデートの修正
- $?が正常に解釈されていなかったので修正
- 構文解析で、先頭が'|'のときにsyntax errorを検出