### PR TITLE
fix: bashの挙動に合わせるため、リダイレクトの管理を入出力で分けずに、まとめて順番に管理するように変更

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/13 14:13:46 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/20 11:19:39 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 12:14:33 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,8 +74,7 @@ typedef struct s_rdrct
 typedef struct s_cmd
 {
 	char	**cmd;
-	t_rdrct	**input_rdrct;
-	t_rdrct	**output_rdrct;
+	t_rdrct	**rdrcts;
 	int		infile_fd;
 	int		outfile_fd;
     int     backup_stdin;
@@ -153,8 +152,8 @@ t_list	*tokenize(char *line);
 bool	check_syntax(t_list *tokens);
 bool	split_tokens(t_list ***splited_tokens, t_list *tokens);
 t_list	*splited_tokens_to_cmd_list(t_list **splited_tokens, t_parser data);
-bool	get_rdrcts(t_rdrct ***rdrcts, t_list **tokens, char key, t_parser data);
-bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens, char key);
+bool	get_rdrcts(t_rdrct ***rdrcts, t_list **tokens, t_parser data);
+bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens);
 t_list	*expand_env_quote(char *token, t_parser data);
 char	*recursive_expand(char **token, t_parser *data, t_quote quote, int len);
 bool	is_in_quote(char c, t_quote *quote, bool is_include_quote);

--- a/parser_free.c
+++ b/parser_free.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 12:08:45 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/19 23:11:28 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 12:15:05 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,8 @@ void	free_cmd(void *content)
 	cmd = (t_cmd *)content;
 	if (cmd->cmd)
 		free_double_pointor(cmd->cmd);
-	if (cmd->input_rdrct)
-		free_rdrcts((void *)cmd->input_rdrct);
-	if (cmd->output_rdrct)
-		free_rdrcts((void *)cmd->output_rdrct);
+	if (cmd->rdrcts)
+		free_rdrcts((void *)cmd->rdrcts);
 	free(cmd);
 }
 

--- a/parser_redirect.c
+++ b/parser_redirect.c
@@ -17,12 +17,12 @@ static char		**set_heredocument(char *token);
 static char		**set_file_name(char *token, t_parser data);
 static t_rdrct	**list_to_rdrcts(t_list *rdrct_list);
 
-bool	get_rdrcts(t_rdrct ***rdrcts, t_list **tokens, char key, t_parser data)
+bool	get_rdrcts(t_rdrct ***rdrcts, t_list **tokens, t_parser data)
 {
 	t_list	*rdrct_list;
 
 	rdrct_list = NULL;
-	if (!get_rdrct_list(&rdrct_list, tokens, key))
+	if (!get_rdrct_list(&rdrct_list, tokens))
 		return (false);
 	*rdrcts = list_to_rdrcts(rdrct_list);
 	if (!*rdrcts)

--- a/parser_redirect_utils.c
+++ b/parser_redirect_utils.c
@@ -12,12 +12,12 @@
 
 #include <minishell.h>
 
-static bool			get_rdrct(t_rdrct **rdrct, t_list **tokens, char key);
-static t_rdrct_type	get_rdrct_type(char *token, char key);
+static bool			get_rdrct(t_rdrct **rdrct, t_list **tokens);
+static t_rdrct_type	get_rdrct_type(char *token);
 static t_rdrct		*create_rdrct(t_rdrct_type type, char *token);
 static void			rejoin_tokens(t_list **tokens, t_list *cur, t_list *prev);
 
-bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens, char key)
+bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens)
 {
 	t_rdrct	*rdrct;
 	t_list	*rdrct_node;
@@ -25,7 +25,7 @@ bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens, char key)
 	while (true)
 	{
 		rdrct = NULL;
-		if (!get_rdrct(&rdrct, tokens, key))
+		if (!get_rdrct(&rdrct, tokens))
 		{
 			ft_lstclear(rdrct_list, free);
 			return (false);
@@ -44,7 +44,7 @@ bool	get_rdrct_list(t_list **rdrct_list, t_list **tokens, char key)
 	return (true);
 }
 
-static bool	get_rdrct(t_rdrct **rdrct, t_list **tokens, char key)
+static bool	get_rdrct(t_rdrct **rdrct, t_list **tokens)
 {
 	t_list			*prev;
 	t_list			*cur;
@@ -56,7 +56,7 @@ static bool	get_rdrct(t_rdrct **rdrct, t_list **tokens, char key)
 	while (cur)
 	{
 		token = (char *)cur->content;
-		rdrct_type = get_rdrct_type(token, key);
+		rdrct_type = get_rdrct_type(token);
 		if (rdrct_type != NONE_RDRCT)
 		{
 			cur = cur->next;
@@ -73,22 +73,16 @@ static bool	get_rdrct(t_rdrct **rdrct, t_list **tokens, char key)
 	return (true);
 }
 
-static t_rdrct_type	get_rdrct_type(char *token, char key)
+static t_rdrct_type	get_rdrct_type(char *token)
 {
-	if (token[0] == key && token[1] == '\0')
-	{
-		if (key == '<')
-			return (INPUT_RDRCT);
-		else
-			return (OVERWRITE_RDRCT);
-	}
-	else if (token[0] == key && token[1] == key && token[2] == '\0')
-	{
-		if (key == '<')
-			return (HEREDOCUMENT);
-		else
-			return (APPEND_RDRCT);
-	}
+	if (token[0] == '<' && token[1] == '\0')
+		return (INPUT_RDRCT);
+	else if (token[0] == '>' && token[1] == '\0')
+		return (OVERWRITE_RDRCT);
+	else if (token[0] == '>' && token[1] == '>' && token[2] == '\0')
+		return (APPEND_RDRCT);
+	else if (token[0] == '<' && token[1] == '<' && token[2] == '\0')
+		return (HEREDOCUMENT);
 	return (NONE_RDRCT);
 }
 

--- a/parser_tokens_to_cmd.c
+++ b/parser_tokens_to_cmd.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 11:44:47 by hkoizumi          #+#    #+#             */
-/*   Updated: 2025/03/19 22:57:35 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 12:14:43 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,7 @@ static t_cmd	*tokens_to_cmd(t_list *tokens, t_parser data)
 	cmd = (t_cmd *)ft_calloc(1, sizeof(t_cmd));
 	if (!cmd)
 		return (NULL);
-	if (!get_rdrcts(&(cmd->input_rdrct), &tokens, '<', data)
-		|| !get_rdrcts(&(cmd->output_rdrct), &tokens, '>', data)
+	if (!get_rdrcts(&(cmd->rdrcts), &tokens, data)
 		|| !get_cmd(&(cmd->cmd), &tokens, data))
 	{
 		free_cmd((void *)cmd);

--- a/pipe_command.c
+++ b/pipe_command.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe_command.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
+/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 12:30:41 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 11:32:45 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 12:16:35 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,11 +17,11 @@ int	process_heredocs(t_cmd *cmd)
 	int	j;
 
 	j = 0;
-	while (cmd->input_rdrct[j])
+	while (cmd->rdrcts[j])
 	{
-		if (cmd->input_rdrct[j]->type == HEREDOCUMENT)
+		if (cmd->rdrcts[j]->type == HEREDOCUMENT)
 		{
-			if (handle_heredocument(cmd->input_rdrct[j]->file[0], cmd) == -1)
+			if (handle_heredocument(cmd->rdrcts[j]->file[0], cmd) == -1)
 				return (-1);
 		}
 		j++;
@@ -70,10 +70,10 @@ bool has_input_redirection(t_cmd *cmd)
 {
     int j = 0;
     
-    while (cmd->input_rdrct[j])
+    while (cmd->rdrcts[j])
     {
-        if (cmd->input_rdrct[j]->type == INPUT_RDRCT || 
-            cmd->input_rdrct[j]->type == HEREDOCUMENT)
+        if (cmd->rdrcts[j]->type == INPUT_RDRCT || 
+            cmd->rdrcts[j]->type == HEREDOCUMENT)
             return true;
         j++;
     }
@@ -83,10 +83,10 @@ bool has_input_redirection(t_cmd *cmd)
 bool has_output_redirection(t_cmd *cmd)
 {
     int j = 0;
-    while (cmd->output_rdrct[j])
+    while (cmd->rdrcts[j])
     {
-        if (cmd->output_rdrct[j]->type == OVERWRITE_RDRCT || 
-            cmd->output_rdrct[j]->type == APPEND_RDRCT)
+        if (cmd->rdrcts[j]->type == OVERWRITE_RDRCT || 
+            cmd->rdrcts[j]->type == APPEND_RDRCT)
             return true;
         j++;
     }

--- a/redirect.c
+++ b/redirect.c
@@ -6,7 +6,7 @@
 /*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/16 20:05:03 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/19 23:34:00 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 12:17:53 by hkoizumi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,22 +82,17 @@ int	handle_redirection(t_cmd *cmd)
 		return (-1);
 		
 	j = 0;
-	while (cmd->input_rdrct[j])
+	while (cmd->rdrcts[j])
 	{
-		if (cmd->input_rdrct[j]->type == INPUT_RDRCT)
+		if (cmd->rdrcts[j]->type == INPUT_RDRCT)
 		{
-			if (handle_input_rdrct(cmd, cmd->input_rdrct[j]) == -1)
+			if (handle_input_rdrct(cmd, cmd->rdrcts[j]) == -1)
 				return (-1);
 		}
-		j++;
-	}
-	j = 0;
-	while (cmd->output_rdrct[j])
-	{
-		if (cmd->output_rdrct[j]->type == OVERWRITE_RDRCT
-			|| cmd->output_rdrct[j]->type == APPEND_RDRCT)
+		else if (cmd->rdrcts[j]->type == OVERWRITE_RDRCT
+			|| cmd->rdrcts[j]->type == APPEND_RDRCT)
 		{
-			if (handle_output_rdrct(cmd, cmd->output_rdrct[j]) == -1)
+			if (handle_output_rdrct(cmd, cmd->rdrcts[j]) == -1)
 				return (-1);
 		}
 		j++;


### PR DESCRIPTION
input,outpu問わず、順番にリダイレクトのファイルopenし、エラーが出た時点でキャンセルさせるため、受け取ったリダイレクトの順番を保持できるようinput_rdrctとoutput_rdrctをrdrctsに統合
それに合わせてリダイレクト実行周りの関数の仕様も修正