### PR TITLE
ヒアドキュメントの処理をパイプから一時ファイルに変更、二重で複製していたFDのエラーを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,18 @@ CC = cc
 RM = rm
 FSANITIZE = -fsanitize=address
 CFLAGS = -Wall -Wextra -Werror 
-INCLUDES = -I./includes -I/usr/local/opt/readline/include
-READLINE = -lreadline -L/usr/local/opt/readline/lib 
+
+# OSに応じた設定
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    # MacOS用の設定
+    INCLUDES = -I./includes -I/usr/local/opt/readline/include
+    READLINE = -L/usr/local/opt/readline/lib -lreadline
+else
+    # Linux用の設定
+    INCLUDES = -I./includes
+    READLINE = -lreadline
+endif
 
 LIBFT_DIR = libft
 LIBFT = $(LIBFT_DIR)/libft.a
@@ -77,9 +87,9 @@ MAIN = $(OBJ_DIR)/main.o
 # デフォルトターゲット
 all: $(NAME)
 
-# バイナリ生成ルール
+# バイナリ生成ルール（リンカオプションの順序を修正）
 $(NAME): $(MAIN) $(OBJS) $(LIBFT)
-	$(CC) $(CFLAGS) $(READLINE) $(INCLUDES) $(MAIN) $(OBJS) $(LIBFT) -o $(NAME)
+	$(CC) $(CFLAGS) $(INCLUDES) $(MAIN) $(OBJS) $(LIBFT) $(READLINE) -o $(NAME)
 
 # ソースファイルからオブジェクトファイル生成
 $(OBJ_DIR)/%.o: %.c | $(OBJ_DIR)

--- a/builtin_exit.c
+++ b/builtin_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 00:54:17 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 03:33:11 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 23:42:22 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ int is_numeric(const char *str) {
 int builtin_exit(char **cmd, t_list *env) {
 
 	(void)env;
-    write(STDOUT_FILENO, "exit\n", 5);
+    // write(STDOUT_FILENO, "exit\n", 5);
 
     if (cmd[1] != NULL) {
         if (!is_numeric(cmd[1])) {

--- a/heredocument.c
+++ b/heredocument.c
@@ -6,98 +6,94 @@
 /*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 17:33:18 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 02:39:44 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 23:48:17 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-static int setup_heredoc_pipe(int pipe_fds[2], t_cmd *cmd)
+static int	create_temp_file(void)
 {
-    if (pipe(pipe_fds) == -1)
-    {
-        perror("pipe");
-        return (-1);
-    }
-    if (cmd->backup_stdin == -1)
-    {
-        cmd->backup_stdin = dup(STDIN_FILENO);
-        if (cmd->backup_stdin == -1)
-        {
-            perror("dup");
-            close(pipe_fds[0]);
-            close(pipe_fds[1]);
-            return (-1);
-        }
-    }
-    else
-    {
-        dup2(cmd->backup_stdin, STDIN_FILENO);
-    }
-    return (0);
+	int	tmp_fd;
+
+	tmp_fd = open("/tmp/minishell_heredoc", O_RDWR | O_CREAT | O_TRUNC, 0600);
+	if (tmp_fd == -1)
+	{
+		perror("open");
+		return (-1);
+	}
+	return (tmp_fd);
 }
 
-static void	process_heredoc_child(int pipe_fds[2], char *delimiter)
+static int	write_heredoc_content(int tmp_fd, char *delimiter)
 {
 	char	*line;
 	size_t	delimiter_len;
 
 	delimiter_len = ft_strlen(delimiter);
-	close(pipe_fds[0]);
 	while (1)
 	{
 		write(STDOUT_FILENO, "> ", 2);
 		line = get_next_line(STDIN_FILENO);
 		if (!line || (ft_strncmp(line, delimiter, delimiter_len) == 0
-				            && ft_strlen(line) - 1 == delimiter_len))
+				&& ft_strlen(line) - 1 == delimiter_len))
 		{
 			free(line);
 			break ;
 		}
-		write(pipe_fds[1], line, ft_strlen(line));
+		if (write(tmp_fd, line, ft_strlen(line)) == -1)
+		{
+			free(line);
+			return (-1);
+		}
 		free(line);
 	}
-	close(pipe_fds[1]);
-	exit(0);
+	return (0);
 }
 
-static int	setup_parent_process(int pipe_fds[2], t_cmd *cmd, pid_t pid)
+static int	setup_heredoc_input(int tmp_fd)
 {
-	waitpid(pid, NULL, 0);
-	close(pipe_fds[1]);
-	if (dup2(pipe_fds[0], STDIN_FILENO) == -1)
+	close(tmp_fd);
+	tmp_fd = open("/tmp/minishell_heredoc", O_RDONLY);
+	if (tmp_fd == -1)
 	{
-		perror("dup2");
-		close(cmd->backup_stdin);
-		cmd->backup_stdin = -1;
-		close(pipe_fds[0]);
+		perror("open");
 		return (-1);
 	}
-	close(pipe_fds[0]);
+	if (dup2(tmp_fd, STDIN_FILENO) == -1)
+	{
+		perror("dup2");
+		close(tmp_fd);
+		return (-1);
+	}
+	unlink("/tmp/minishell_heredoc");
+	close(tmp_fd);
 	return (0);
 }
 
 int	handle_heredocument(char *delimiter, t_cmd *cmd)
 {
-	int		pipe_fds[2];
-	pid_t	pid;
-
-	if (setup_heredoc_pipe(pipe_fds, cmd) == -1)
-		return (-1);
-	pid = fork();
-	if (pid == -1)
+    
+	int	tmp_fd;
+	
+	if (cmd->backup_stdin == -1)
 	{
-		perror("fork");
-		close(cmd->backup_stdin);
-		cmd->backup_stdin = -1;
-		close(pipe_fds[0]);
-		close(pipe_fds[1]);
+		cmd->backup_stdin = dup(STDIN_FILENO);
+		if (cmd->backup_stdin == -1)
+		{
+			perror("dup");
+			return (-1);
+		}
+	}
+	tmp_fd = create_temp_file();
+	if (tmp_fd == -1)
+		return (-1);
+	if (write_heredoc_content(tmp_fd, delimiter) == -1)
+	{
+		close(tmp_fd);
 		return (-1);
 	}
-	if (pid == 0)
-		process_heredoc_child(pipe_fds, delimiter);
-	return (setup_parent_process(pipe_fds, cmd, pid));
+	if (setup_heredoc_input(tmp_fd) == -1)
+		return (-1);
+	return (0);
 }
-
-
-

--- a/redirect.c
+++ b/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hkoizumi <hkoizumi@student.42.fr>          +#+  +:+       +#+        */
+/*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/16 20:05:03 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 12:17:53 by hkoizumi         ###   ########.fr       */
+/*   Updated: 2025/03/20 23:09:54 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,20 +14,26 @@
 
 int	backup_io(t_cmd *cmd)
 {
-	cmd->backup_stdin = dup(STDIN_FILENO);
-	if (cmd->backup_stdin == -1)
-	{
-		perror("dup");
-		return (-1);
-	}
-	cmd->backup_stdout = dup(STDOUT_FILENO);
-	if (cmd->backup_stdout == -1)
-	{
-		perror("dup");
-		close(cmd->backup_stdin);
-		cmd->backup_stdin = -1;
-		return (-1);
-	}
+    if (cmd->backup_stdin == -1)
+    {
+        cmd->backup_stdin = dup(STDIN_FILENO);
+        if (cmd->backup_stdin == -1)
+        {
+            perror("dup");
+            return (-1);
+        }
+    }
+    if (cmd->backup_stdout == -1)
+    {
+        cmd->backup_stdout = dup(STDOUT_FILENO);
+        if (cmd->backup_stdout == -1)
+        {
+            perror("dup");
+            close(cmd->backup_stdin);
+            cmd->backup_stdin = -1;
+            return (-1);
+        }
+    }
 	return (0);
 }
 

--- a/redirect_utils.c
+++ b/redirect_utils.c
@@ -6,7 +6,7 @@
 /*   By: shiori <shiori@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 19:16:44 by shiori            #+#    #+#             */
-/*   Updated: 2025/03/20 12:30:57 by shiori           ###   ########.fr       */
+/*   Updated: 2025/03/20 22:57:29 by shiori           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,24 +14,9 @@
 
 int restore_redirection(t_cmd *cmd)
 {
-    char buffer[1024];
-    struct termios term, old_term;
-    
-    tcgetattr(STDIN_FILENO, &old_term);
-    
-    term = old_term;
-    term.c_lflag &= ~(ICANON | ECHO);
-    term.c_cc[VMIN] = 0;
-    term.c_cc[VTIME] = 0;
-    tcsetattr(STDIN_FILENO, TCSANOW, &term);
-    
-    while (read(STDIN_FILENO, buffer, sizeof(buffer)) > 0)
-        ;
-    
-    tcsetattr(STDIN_FILENO, TCSANOW, &old_term);
-    
     if (cmd->backup_stdin != -1)
     {
+        
         if (dup2(cmd->backup_stdin, STDIN_FILENO) == -1)
         {
             perror("dup2");


### PR DESCRIPTION
ヒアドキュメントの入力内容がコマンドとして実行されてしまう問題ですが、ヒアドキュメントの処理で複製した標準入力FDをその後のhandle_redirectionのbackup_io関数内でさらに複製してしまい、正しいFDをrestoreできていませんでした。そのため、backup_io関数内でヒアドキュメント処理でFDがすでにバックアップされているかで条件分岐をするようにしました。

複数ヒアドキュメントの対応ですが、ヒアドキュメント処理に入る前にFDをバックアップしていた標準入力に戻し、ユーザーからの入力を受け取れるようにしました（以前とほとんど同じです）。